### PR TITLE
Fixed vram to vram copy.

### DIFF
--- a/decompressors/dzx0_fast_sms.asm
+++ b/decompressors/dzx0_fast_sms.asm
@@ -298,6 +298,12 @@ _below256:
   ; and saves some push/pops; and we can use djnz for the loop.
   ld b,c
   ld c,$bf
+
+  call +
+
+  pop af
+  ret
+
 +:
 -:out (c),l
   out (c),h
@@ -309,7 +315,6 @@ _below256:
   inc de
   djnz -
   ld c,0
-  pop af
   ret
 
 _ldir_rom_to_vram:

--- a/decompressors/dzx0_standard_sms.asm
+++ b/decompressors/dzx0_standard_sms.asm
@@ -106,6 +106,12 @@ _below256:
   ; and saves some push/pops; and we can use djnz for the loop.
   ld b,c
   ld c,$bf
+
+  call +
+
+  pop af
+  ret
+
 +:
 -:out (c),l
   out (c),h
@@ -117,7 +123,6 @@ _below256:
   inc de
   djnz -
   ld c,0
-  pop af
   ret
 
 _ldir_rom_to_vram:


### PR DESCRIPTION
For VRAM to VRAM copies of longer than 256 bytes there is a problem with a 'pop af' at the wrong location.